### PR TITLE
Fix deprecation warnings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 root:
 permalink: /:year/:month/:day/:title
 lsi: false
-pygments: true
+highlights: true
 markdown: kramdown
 gems:
   - jekyll-redirect-from

--- a/feed.xml
+++ b/feed.xml
@@ -1,5 +1,5 @@
 ---
-layout: none
+layout: null
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
This fixes a couple of the small deprecation warnings when running Jekyll. 
