### PR TITLE
add google plus link to the footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -111,6 +111,7 @@
         <li><a class="applicationFooterListLink" href="https://github.com/apiaryio">GitHub</a></li>
         <li><a class="applicationFooterListLink" href="https://twitter.com/apiaryio">Twitter</a></li>
         <li><a class="applicationFooterListLink" href="https://facebook.com/apiary.io">Facebook</a></li>
+        <li><a class="applicationFooterListLink" href="https://plus.google.com/114367708466177247933/about">Google+</a></li>
         <li><a class="applicationFooterListLink" href="http://dribbble.com/apiary">Dribbble</a></li>
       </ul>
     </div></div>


### PR DESCRIPTION
Trello: https://trello.com/c/gE9c0vnS/2279-link-google-page-to-website
