### PR TITLE
Add HTTPS support to blog (1st part)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ gems:
   - jekyll-redirect-from
 
 # Site configuration
-url:          http://blog.apiary.io
+url:          https://blog.apiary.io
 title:        The Apiary Blog
 description:  Updates on everyone's favourite REST API tools company
 authors:
@@ -79,14 +79,14 @@ authors:
 keywords:     rest, api, tools, json, debugging, proxy, documentation, testing, tests, support
 author:       Apiary
 email:        jakub@apiary.io
-static: "http://apiary-static.s3.amazonaws.com/assets"
+static: "https://apiary-static.s3.amazonaws.com/assets"
 # static: "https://static.apiary.dev:9000"
 version: 1338364425
 menu:
   - ['http://apiary.io/how-it-works', 'How It Works']
   - ['http://apiary.io/pricing', 'Pricing']
   - ['http://apiary.io/products', 'Product']
-  - ['http://blog.apiary.io/', 'Blog']
+  - ['https://blog.apiary.io/', 'Blog']
   - ['http://apiary.io/company', 'Company']
   - ['https://login.apiary.io/login', 'Sign In']
 tracking: >


### PR DESCRIPTION
https://trello.com/c/YcyqM4W5/199-enable-hsts-on-https-apiary-io

2nd part will be when all apiary.io domains are switched to
https, then the links will need to be changed, though it is not
that vital as they will all get forwarded from HTTP to HTTPS.