### PR TITLE
Use CircleCI to deploy the blog

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -65,3 +65,40 @@ task :serve => 'serve:drafts'
 
 task :default => :serve
 
+desc 'Deploy the blog to GitHub pages'
+task :deploy do
+  FileUtils.rm_rf '_gh-pages'
+  puts 'Cloning gh-pages branch...'
+  url = `git ls-remote --get-url origin`
+  puts `git clone #{url.strip} _gh-pages`
+  Dir.chdir('_gh-pages') do
+    puts `git checkout gh-pages`
+  end
+
+  Dir.chdir('_gh-pages') do
+    puts 'Pulling changes from server.'
+    puts `git reset --hard`
+    puts `git clean -xdf`
+    puts `git checkout gh-pages`
+    puts `git pull origin gh-pages`
+  end
+
+  puts 'Building site.'
+  puts `bundle exec jekyll build -d _gh-pages`
+
+  Dir.chdir('_gh-pages') do
+    puts 'Pulling changes from server.'
+    puts `git checkout gh-pages`
+    puts `git pull origin gh-pages`
+
+    puts 'Creating a commit for the deploy.'
+
+    puts `git ls-files --deleted -z | xargs -0 git rm;`
+    puts `git add .`
+    puts `git commit -m "Deploy"`
+
+    puts 'Pushing to github.'
+    puts `git push --quiet > /dev/null 2>&1`
+  end
+end
+

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,7 @@ highlights: true
 highlighter: rouge
 gems:
   - jekyll-redirect-from
+exclude: [vendor]
 
 # Site configuration
 url:          http://blog.apiary.io

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+deployment:
+  production:
+    branch: master
+    commands:
+      - git config --global user.name "Apiary Bot"
+      - git config --global user.email "support@apiary.io"
+      - git remote set-url origin "https://${GH_TOKEN}@github.com/apiaryio/apiaryio.github.com"
+      - rake deploy
+test:
+  override:
+    - bundle exec jekyll doctor


### PR DESCRIPTION
Due to limitations with automatic GitHub pages using Jekyll. I've made this pull request to instead use CircleCI to build and deploy the blog.

The limitation is mostly the fact we can't have [syntax highlighting with Rouge](https://github.com/apiaryio/apiaryio.github.com/pull/51#issuecomment-99409367), and we also can't control the dependencies (and versions) that we use.

There are a couple of tasks that need to be done before merging this else it will fail:

- [ ] Create a `gh-pages` branch (manual deploy beforehand) - I will do this once it's been reviewed and gotten a :+1:.
- [ ] Grant @ApiaryBot push/write access to [this repository](https://github.com/apiaryio/apiaryio.github.com).
- [ ] Merge.

While we're doing this, perhaps it would make sense to rename this repository to `blog.apiary.io` instead of `apiary.github.com` so it's more clear what the contents is from the name.

/cc @abtris