### PR TITLE
Use the ONLY highlighter supported by GitHub

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ kramdown:
   hard_wrap: false
   syntax_highlighter: rouge
 highlights: true
-highlighter: rouge
+highlighter: pygments
 gems:
   - jekyll-redirect-from
 exclude: ['Gemfile*', 'vendor', 'README.md', 'Rakefile']


### PR DESCRIPTION
Address the highlighter build warning.

> If you attempt to define a highlighter other than pygments for use
with GitHub Pages, you'll receive a page build warning. GitHub Pages
does not support other highlighters, such as rouge, and will
automatically use the default pygments.

See
https://help.github.com/articles/page-build-failed-config-file-error/#highlighting-errors