### PR TITLE
Fix 404 on accessing blog post urls with trailing slash

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 ---
 root:
-permalink: /:year/:month/:day/:title
+permalink: /:year/:month/:day/:title/
 lsi: false
 markdown: kramdown
 kramdown:


### PR DESCRIPTION
- add trailing slash to `permalink` in config file (see https://jekyllrb.com/docs/upgrading/2-to-3/#permalinks-no-longer-automatically-add-a-trailing-slash)

I believe this should help with the 404s (e.g. for https://blog.apiary.io/2014/03/21/Re-API-Design-for-Humans/)