### PR TITLE
Canonical tag and sitemap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@ source 'https://rubygems.org'
 gem 'jekyll'
 gem 'jekyll-redirect-from'
 gem 'rouge'
+
+group :jekyll_plugins do
+  gem 'jekyll-sitemap'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
       jekyll (~> 2.0)
     jekyll-sass-converter (1.2.1)
       sass (~> 3.2)
+    jekyll-sitemap (0.10.0)
     jekyll-watch (1.1.1)
       listen (~> 2.7)
     kramdown (1.5.0)

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,7 @@ highlights: true
 highlighter: rouge
 gems:
   - jekyll-redirect-from
+  - jekyll-sitemap
 exclude: ['Gemfile*', 'vendor', 'README.md', 'Rakefile']
 
 # Site configuration

--- a/_config.yml
+++ b/_config.yml
@@ -105,7 +105,7 @@ menu:
   - ['https://apiary.io/how-it-works', 'How It Works']
   - ['https://apiary.io/pricing', 'Pricing']
   - ['https://apiary.io/products', 'Product']
-  - ['https://docs.apiary.io/', 'Docs']
+  - ['https://help.apiary.io/', 'Help']
   - ['https://apiary.io/company', 'Company']
   - ['https://login.apiary.io/login', 'Sign In']
 tracking: >

--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ gems:
 exclude: ['Gemfile*', 'vendor', 'README.md', 'Rakefile']
 
 # Site configuration
-url:          http://blog.apiary.io
+url:          https://blog.apiary.io
 title:        The Apiary Blog
 description:  Updates on everyone's favourite REST API tools company
 authors:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,6 +33,7 @@
   {% endif %}
 
   <link rel="shortcut icon" href="/favicon.ico">
+  <link rel="canonical" href="{{ site.url }}{{ page.url | replace:'index.html',''}}">
 
   <!-- Styles -->
   <link rel="stylesheet" href="{{ site.static }}/styles/fonts.css">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -63,7 +63,7 @@
         {% endfor %}
       </ul>
       <a class="websiteNavLink websiteNavLinkHighlighted" href="https://login.apiary.io/register" class="signIn">Sign Up</a>
-      <a class="websiteNavLink backToTop" href="#~"><span class="visuallyhidden">Back to top</span></a>
+      <a class="websiteNavLink backToTop" href="javascript:;"><span class="visuallyhidden">Back to top</span></a>
     </nav>
   </div>
 <!-- /website-navigation -->
@@ -87,7 +87,7 @@
         <li><a class="applicationFooterListLink" href="http://apiary.io/products">Product</a></li>
         <li><a class="applicationFooterListLink" href="http://enterprise.apiary.io/">Enterprise</a></li>
         <li><a class="applicationFooterListLink" href="http://apiary.io/pricing">Pricing</a></li>
-        <li><a class="applicationFooterListLink" href="http://docs.apiary.io ">Docs</a></li>
+        <li><a class="applicationFooterListLink" href="https://help.apiary.io">Help</a></li>
       </ul>
     </div><div class="applicationFooterColumn">
       <h3 class="applicationFooterTitle">Company</h3>
@@ -113,7 +113,6 @@
         <li><a class="applicationFooterListLink" href="https://github.com/apiaryio">GitHub</a></li>
         <li><a class="applicationFooterListLink" href="https://twitter.com/apiaryio">Twitter</a></li>
         <li><a class="applicationFooterListLink" href="https://facebook.com/apiary.io">Facebook</a></li>
-        <li><a class="applicationFooterListLink" href="https://plus.google.com/114367708466177247933/about">Google+</a></li>
         <li><a class="applicationFooterListLink" href="http://dribbble.com/apiary">Dribbble</a></li>
       </ul>
     </div></div>


### PR DESCRIPTION
- added canonical link
- added sitemap generator for blog

## On new URLs
- https (enforced by cloudflare)
- no trailing slash
- 301 redirects for pages are setup

```html
<link rel="canonical" href="https://blog.apiary.io/2016/04/21/API-Design-Hackaton">
```

---

After merging we should only verify that `canonical` URL in header is always the same as the one in URL bar.

Ping @nadade 
Closes #84