### PR TITLE
Remove download/preview links to editor

### DIFF
--- a/_posts/2014-01-09-Inspirational-Resources.md
+++ b/_posts/2014-01-09-Inspirational-Resources.md
@@ -18,44 +18,40 @@ Bellow you can find a short list of selected blueprints alongside with notes on 
 
 ## Selected API blueprints:
 
-- [**GHD Registration Portal**](https://github.com/worldspawn/apiary/blob/master/apiary.apib) – [*view in Apiary*](https://app.apiary.io/download/editor?from=https://raw.githubusercontent.com/worldspawn/apiary/master/apiary.apib)
+- [**GHD Registration Portal**](https://github.com/worldspawn/apiary/blob/master/apiary.apib)
  
 	*application/hal+json, error codes, URI parameters, resource description, resource model*
 	
-- [**H2O REST API**](https://github.com/mmalohlava/babylon4apiaryio/blob/master/apiary.apib) – [*view in Apiary*](https://app.apiary.io/download/editor?from=https://raw.githubusercontent.com/mmalohlava/babylon4apiaryio/master/apiary.apib)
+- [**H2O REST API**](https://github.com/mmalohlava/babylon4apiaryio/blob/master/apiary.apib)
 
 	*error codes, URI parameters*
 	
-- [**Open Ed**](https://github.com/openedinc/openedapi/blob/master/apiary.apib) – [*view in Apiary*](https://app.apiary.io/download/editor?from=https://raw.githubusercontent.com/openedinc/openedapi/master/apiary.apib)
+- [**Open Ed**](https://github.com/openedinc/openedapi/blob/master/apiary.apib)
 
 	*authentication, error codes, URI parameters*
 
-- [**Appliance API**](https://github.com/t0mpr1c3/homenet-apib/blob/master/apiary.apib) – [*view in Apiary*](https://app.apiary.io/download/editor?from=https://raw.githubusercontent.com/t0mpr1c3/homenet-rest/master/apiary.apib)
+- [**Appliance API**](https://github.com/t0mpr1c3/homenet-apib/blob/master/apiary.apib)
 
 	*exemplar collection and item resource design, URI parameters*
 
-- [**POD API**](https://github.com/dwcaraway/podserve/blob/master/apiary.apib) – [*view in Apiary*](https://app.apiary.io/download/editor?from=https://raw.githubusercontent.com/dwcaraway/podserve/master/apiary.apib)
+- [**POD API**](https://github.com/dwcaraway/podserve/blob/master/apiary.apib)
 
 	*exemplar collection and item resource design, URI parameters*
 
-- [**Notificare Push API**](https://github.com/Notificare/apiblueprint/blob/master/apiary.apib) – [*view in Apiary*](https://app.apiary.io/download/editor?from=https://raw.githubusercontent.com/Notificare/apiblueprint/master/apiary.apib)
+- [**Notificare Push API**](https://github.com/Notificare/apiblueprint/blob/master/apiary.apib)
 
 	*exemplar collection and item resource design, nested resources, URI parameters*
 
-- [**Tesla Model S REST API**](https://github.com/timdorr/model-s-api/blob/master/apiary.apib) – [*view in Apiary*](https://app.apiary.io/download/editor?from=https://raw.githubusercontent.com/timdorr/model-s-api/master/apiary.apib)
+- [**Tesla Model S REST API**](https://github.com/timdorr/model-s-api/blob/master/apiary.apib)
 
 	*a car with an API!*
 
-- [**Helpful API**](https://github.com/asm-helpful/helpful-web/blob/master/apiary.apib) – [*view in Apiary*](https://app.apiary.io/download/editor?from=https://raw.githubusercontent.com/asm-helpful/helpful-web/master/apiary.apib)
+- [**Helpful API**](https://github.com/asm-helpful/helpful-web/blob/master/apiary.apib)
 
 	*custom media type based on application/hal+json, HTTP link header, authentication, resource description, URI parameters, resource model, exemplar collection and item resource design, apparently work in progress*
 
-In addition to these blueprints there are always official [API Blueprint Examples](https://github.com/apiaryio/api-blueprint/tree/master/examples) available. For example the [**Gist Fox API**](https://github.com/apiaryio/api-blueprint/blob/master/examples/Gist%20Fox%20API.md) ([*view in Apiary*](https://app.apiary.io/download/editor?from=https://raw.githubusercontent.com/apiaryio/api-blueprint/master/examples/Gist%20Fox%20API.md)).
+In addition to these blueprints there are always official [API Blueprint Examples](https://github.com/apiaryio/api-blueprint/tree/master/examples) available. For example the [**Gist Fox API**](https://github.com/apiaryio/api-blueprint/blob/master/examples/Gist%20Fox%20API.md)
 
 Hope you were able to find some inspiration or answer to your questions. But don't get carried away for too long. Crafting actual API has never been easier!
 
 Remember to use [**Stack Overflow**](http://stackoverflow.com/questions/tagged/apiblueprint) to ask questions on writing API blueprints.
-
-*Note: You can load any arbitrary, publicly available, blueprint into Apiary editor. While signed in to Apiary, simply append the blueprint's URL to `https://app.apiary.io/download/editor?from=` in your browser's address bar.*
-
-


### PR DESCRIPTION
We should remove these links, as this is an undocumented, possibly dangerous, untested and currently useless functionality.