### PR TITLE
Change date-time of Markdown post to a real time

### DIFF
--- a/_posts/2016-09-28-markdown.md
+++ b/_posts/2016-09-28-markdown.md
@@ -2,7 +2,7 @@
 title: The next chapter for Markdown
 excerpt: Apiary is embracing the CommonMark Markdown syntax for API description.
 layout: post
-date: 2016-09-28 00:00:00 +0200
+date: 2016-09-28 10:00:00 +0200
 author: zdenek
 published: true
 ---


### PR DESCRIPTION
- creates a link to 28 September, not 27th