### PR TITLE
Add TrustArc consent rubbish

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,7 +22,7 @@
   <meta property="og:image" content="{{ site.url | append: '/images/apiary-logotype-3D-only.png' }}">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
-  
+
   {% if page.excerpt %}
     <meta property="og:url" content="{{ site.url }}{{ page.url }}">
     <meta name="description" content="{{ page.excerpt | escape }} &mdash; Apiary Blog">
@@ -120,7 +120,7 @@
   </div>
 
   <div class="applicationFooterRow">
-    <p class="applicationFooterCopyright">Copyright &copy; 2017, Oracle and/or its affiliates. All rights reserved. Oracle and Java are registered trademarks of Oracle and/or its affiliates. Other names may be trademarks of their respective owners. <span class="applicationFooterCopyrightLinks">• <a href="http://apiary.io/tos" class="applicationFooterCopyrightLink">Terms</a> • <a href="https://apiary.io/privacy" class="applicationFooterCopyrightLink">Privacy</a></span></p>
+    <p class="applicationFooterCopyright">Copyright &copy; 2017, Oracle and/or its affiliates. All rights reserved. Oracle and Java are registered trademarks of Oracle and/or its affiliates. Other names may be trademarks of their respective owners. <span class="applicationFooterCopyrightLinks"><a href="https://apiary.io/tos" class="applicationFooterCopyrightLink">Terms</a> • <a href="https://apiary.io/privacy" class="applicationFooterCopyrightLink">Privacy</a> • <span id="teconsent"></span></span></p>
   </div>
 </footer>
 <!-- /website-footer -->
@@ -130,6 +130,7 @@
   websiteScroll();
   document.documentElement.className += ' js';
 </script>
+<script src="https://consent.trustarc.com/notice?domain=apiary.io&amp;c=teconsent&amp;text=true&amp;js=nj&amp;noticeType=bb" async="async" crossorigin=""></script>
 
 </body>
 </html>


### PR DESCRIPTION
⚠️ DEPENDS ON https://github.com/apiaryio/apiary/pull/5666 (CSS styles) ⚠️ 

-----

Per Oracle policies we're required to implement TrustArc cookie consent dialog. We [decided](https://apiary.slack.com/archives/C56PT7LDN/p1529660811000169) we'll proceed with standard installation. In the first iteration, I'm installing this on:

- website https://github.com/apiaryio/apiary/pull/5666
- help https://github.com/apiaryio/help.apiary.io/pull/371
- blog https://github.com/apiaryio/apiaryio.github.com/pull/128

Once the first iteration is deployed, I'll ask the people responsible for TrustArc to check our installation and let's see if they like it or not.

----

The dialog has two parts: the `<script>`, and the element where the dialog opener link is going to be rendered. The latter looks like this:

<img width="555" alt="image" src="https://user-images.githubusercontent.com/283441/43523834-e86b802c-959d-11e8-964e-9b2a427539b0.png">

I had to make some CSS changes to keep it nice. With some changes to colors and stuff I'm also syncing discrepancies between how our copyright footer texts look like on different sites.